### PR TITLE
Hold state can fail after a while resulting in an inaccurate press times.

### DIFF
--- a/Button.h
+++ b/Button.h
@@ -58,7 +58,7 @@ class Button {
     uint8_t             mode;
     uint8_t             state;
     bool                debounceMode;
-    unsigned int        pressedStartTime;
+    unsigned long       pressedStartTime;
     unsigned int        holdEventThreshold;
     unsigned long       debounceStartTime;
     int                 debounceDuration;


### PR DESCRIPTION
Because the millis() is a long and pressedHoldTime is an int, there was an inaccurate comparison and the calculation could result in weird behavior in determining the hold state.
