### PR TITLE
INTERNAL PULLUP for esp8266 board

### DIFF
--- a/Button.cpp
+++ b/Button.cpp
@@ -60,8 +60,12 @@ void Button::pullup(uint8_t buttonMode)
 {
 	mode=BUTTON_PULLUP;
   if (buttonMode == BUTTON_PULLUP_INTERNAL) 
-  {
+  {	  
+#ifdef ESP8266
+	  pinMode(pin, INPUT_PULLUP);
+#else
 	  digitalWrite(pin,HIGH);
+#endif	  
   }
 }
 


### PR DESCRIPTION
`digitalWrite(pin,HIGH)` doesn't work with esp8266 boards with `buttonMode == BUTTON_PULLUP_INTERNAL`